### PR TITLE
support AArch64/ARM64 CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run the docker file from a laptop/ computer while the Openflexure microscope is 
 ```bash
 docker build -t malatec_app .
 
-# if you are using an AArch64/ARM64 CPU (e.g. a Raspberry Pi 4 or later), use:
+# if you are using an AArch64/ARM64 CPU (e.g. a Raspberry Pi with a 64-bit operating system), use:
 docker build -f Dockerfile.aarch64 -t malatec_app .
 ```
 Now you can run the docker file, which starts up the streamlit app:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ docker build -f Dockerfile.aarch64 -t malatec_app .
 Now you can run the docker file, which starts up the streamlit app:
 
 ```bash
-docker run --rm --name malatec_app malatec_app:latest
+# -p 8501:8501 is needed if you want to serve other computers in your network,
+# be sure to use the external IP address of the docker host (not the docker container) to access streamlit in a browser
+docker run --rm --name malatec_app -p 8501:8501 malatec_app:latest
 ```
 Follow the link provided in the console and you should be able to see the streamlit app.
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ Run the docker file from a laptop/ computer while the Openflexure microscope is 
 
 ```bash
 docker build -t malatec_app .
+
+# if you are using an AArch64/ARM64 CPU (e.g. a Raspberry Pi 4 or later), use:
+docker build -f Dockerfile.aarch64 -t malatec_app .
 ```
 Now you can run the docker file, which starts up the streamlit app:
 
 ```bash
-docker run -it --rm --name malatec_app -v /home/fight/Documents/malatec_app/docker  malatec_app:latest
+docker run --rm --name malatec_app malatec_app:latest
 ```
 Follow the link provided in the console and you should be able to see the streamlit app.
 

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -10,7 +10,7 @@ WORKDIR /app
 #
 # this might be no longer necessary in the future if:
 #   - a dev/full version of the base image here is used instead of python:3.7-slim-buster
-#   - or if Python <= 3.9 is used (because then, the backport of zoneinfo is no longer needed)
+#   - or if Python >= 3.9 is used (because then, the backport of zoneinfo is no longer needed)
 #   - or maybe if https://github.com/pganssle/zoneinfo/issues/110 will be solved
 #
 #

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,0 +1,44 @@
+# use python:3.7 for now since its the only Python version supported by the custom ARM64 tensorflow==2.4.0 wheel
+FROM python:3.7-slim-buster
+
+WORKDIR /app
+
+
+# install the "build-essential" package
+# to get the "gcc" binary which is used by the "backports.zoneinfo" Python package
+# which is a dependency of streamlit==0.81 (see requirements.txt)
+#
+# this might be no longer necessary in the future if:
+#   - a dev/full version of the base image here is used instead of python:3.7-slim-buster
+#   - or if Python <= 3.9 is used (because then, the backport of zoneinfo is no longer needed)
+#   - or maybe if https://github.com/pganssle/zoneinfo/issues/110 will be solved
+#
+#
+# also,
+# install the "pkg-config" and "libhdf5-dev" packages to allow the installation of the Python package "h5py" (see requirements.txt)
+# on ARM CPUs, as suggested in https://github.com/h5py/h5py/issues/1461#issuecomment-563118689
+# (this will hopefully no longer be necessary in the future)
+RUN apt update
+RUN apt install build-essential pkg-config libhdf5-dev -y
+
+RUN /usr/local/bin/python -m pip install --upgrade pip
+
+COPY requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt
+
+# we use a custom ARM64 build for tensorflow==2.4.0 since there are no official ARM64 for the full version of TensorFlow:
+RUN pip install --no-deps https://github.com/sanjayseshan/tensorflow-aarch64/releases/download/v2.4.0/tensorflow-2.4.0-cp37-cp37m-linux_aarch64.whl
+# we cannot add this command to requirements.txt since the --no-deps flag is not available in requirements.txt,
+# see https://pip.pypa.io/en/latest/reference/requirements-file-format/#per-requirement-options
+
+
+# cellpose requires large models, load these from cache with:
+RUN python -c 'from cellpose import models'
+
+
+EXPOSE 8501
+
+COPY . .
+ENTRYPOINT ["streamlit","run"]
+CMD ["app.py"]

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-# use python:3.7 for now since its the only Python version supported by the custom ARM64 tensorflow==2.4.0 wheel
+# use python:3.7 for now since its the only Python version supported by the custom AArch64/ARM64 CPU tensorflow==2.4.0 wheel
 FROM python:3.7-slim-buster
 
 WORKDIR /app
@@ -16,7 +16,7 @@ WORKDIR /app
 #
 # also,
 # install the "pkg-config" and "libhdf5-dev" packages to allow the installation of the Python package "h5py" (see requirements.txt)
-# on ARM CPUs, as suggested in https://github.com/h5py/h5py/issues/1461#issuecomment-563118689
+# on AArch64/ARM64 CPUs, as suggested in https://github.com/h5py/h5py/issues/1461#issuecomment-563118689
 # (this will hopefully no longer be necessary in the future)
 RUN apt update
 RUN apt install build-essential pkg-config libhdf5-dev -y
@@ -27,7 +27,7 @@ COPY requirements-aarch64.txt requirements.txt
 
 RUN pip install -r requirements.txt
 
-# we use a custom ARM64 build for tensorflow==2.4.0 since there are no official ARM64 for the full version of TensorFlow:
+# we use a custom AArch64/ARM64 CPU build for tensorflow==2.4.0 since there are no official AArch64/ARM64 CPU builds for the full version of TensorFlow:
 RUN pip install --no-deps https://github.com/sanjayseshan/tensorflow-aarch64/releases/download/v2.4.0/tensorflow-2.4.0-cp37-cp37m-linux_aarch64.whl
 # we cannot add this command to requirements.txt since the --no-deps flag is not available in requirements.txt,
 # see https://pip.pypa.io/en/latest/reference/requirements-file-format/#per-requirement-options

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -23,7 +23,7 @@ RUN apt install build-essential pkg-config libhdf5-dev -y
 
 RUN /usr/local/bin/python -m pip install --upgrade pip
 
-COPY requirements.txt requirements.txt
+COPY requirements-aarch64.txt requirements.txt
 
 RUN pip install -r requirements.txt
 

--- a/docker/app.py
+++ b/docker/app.py
@@ -1,5 +1,5 @@
 # this needs to be imported first, to avoid the error message
-# "cannot allocate memory in static TLS block" when using AArch64 CPUs,
+# "cannot allocate memory in static TLS block" when using AArch64/ARM64 CPUs,
 # see https://github.com/opencv/opencv/issues/14884#issuecomment-599852128
 from skimage.util import img_as_ubyte
 

--- a/docker/app.py
+++ b/docker/app.py
@@ -1,4 +1,4 @@
-# this needs to imported first, to avoid the error message
+# this needs to be imported first, to avoid the error message
 # "cannot allocate memory in static TLS block" when using AArch64 CPUs,
 # see https://github.com/opencv/opencv/issues/14884#issuecomment-599852128
 from skimage.util import img_as_ubyte

--- a/docker/app.py
+++ b/docker/app.py
@@ -1,3 +1,8 @@
+# this needs to imported first, to avoid the error message
+# "cannot allocate memory in static TLS block" when using AArch64 CPUs,
+# see https://github.com/opencv/opencv/issues/14884#issuecomment-599852128
+from skimage.util import img_as_ubyte
+
 import numpy as np
 import streamlit as st
 
@@ -25,7 +30,6 @@ from tensorflow.nn import softmax
 from load_css import local_css
 local_css("style.css")
 
-from skimage.util import img_as_ubyte
 import openflexure_microscope_client as ofm_client
 
 def imread(image_up):

--- a/docker/requirements-aarch64.txt
+++ b/docker/requirements-aarch64.txt
@@ -1,8 +1,11 @@
 # tensorflow 2.4.0 dependencies
-# (we install them explicitly here and install tensorflow itself whith --no-deps flag
-#  because the dependency numpy<1.19.0 described in the tensorflow 2.4.0 wheel
-#  cannot be satisfied (numpy on AArch64 seems to work best starting from version 1.19.0,
-#  at least for the tests on Raspberry Pi 4 Model B))
+#
+# we install them explicitly here and install tensorflow itself whith --no-deps flag
+# because the dependency numpy<1.19.0 described in the tensorflow 2.4.0 wheel
+# cannot be satisfied because wheels for numpy on AArch64 for Linux where only created
+# since version 1.19.0, e.g. compare:
+# https://github.com/numpy/numpy/releases/tag/v1.18.4 wheels vs
+# https://github.com/numpy/numpy/releases/tag/v1.19.0
 absl-py>=0.7.0
 astunparse==1.6.3
 gast==0.3.3

--- a/docker/requirements-aarch64.txt
+++ b/docker/requirements-aarch64.txt
@@ -1,7 +1,8 @@
 # tensorflow 2.4.0 dependencies
 # (we install them explicitly here and install tensorflow itself whith --no-deps flag
 #  because the dependency numpy<1.19.0 described in the tensorflow 2.4.0 wheel
-#  cannot be satisfied (numpy started to support ARM64 in version 1.19.0))
+#  cannot be satisfied (numpy on AArch64 seems to work best starting from version 1.19.0,
+#  at least for the tests on Raspberry Pi 4 Model B))
 absl-py>=0.7.0
 astunparse==1.6.3
 gast==0.3.3

--- a/docker/requirements-aarch64.txt
+++ b/docker/requirements-aarch64.txt
@@ -1,0 +1,32 @@
+# tensorflow 2.4.0 dependencies
+# (we install them explicitly here and install tensorflow itself whith --no-deps flag
+#  because the dependency numpy<1.19.0 described in the tensorflow 2.4.0 wheel
+#  cannot be satisfied (numpy started to support ARM64 in version 1.19.0))
+absl-py>=0.7.0
+astunparse==1.6.3
+gast==0.3.3
+google-pasta>=0.1.8
+grpcio>=1.8.6
+h5py<2.11.0,>=2.10.0
+keras-preprocessing<1.2,>=1.1.1
+opt-einsum>=2.3.2
+protobuf>=3.9.2
+six>=1.12.0
+tensorboard<2.3.0,>=2.2.0
+tensorflow-estimator<2.3.0,>=2.2.0
+termcolor>=1.1.0
+wrapt>=1.11.1
+
+
+numpy
+scikit-image
+matplotlib
+openflexure-microscope-client
+cellpose==0.6.1
+streamlit==0.81
+
+# torch==1.8.1 does not throw 'illegal instruction' SIGILL on ARM64, but newer versions might
+# see https://github.com/JaidedAI/EasyOCR/issues/494#issuecomment-903576063
+--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.1
+torchvision==0.9.1

--- a/docker/requirements-aarch64.txt
+++ b/docker/requirements-aarch64.txt
@@ -2,7 +2,7 @@
 #
 # we install them explicitly here and install tensorflow itself whith --no-deps flag
 # because the dependency numpy<1.19.0 described in the tensorflow 2.4.0 wheel
-# cannot be satisfied because wheels for numpy on AArch64 for Linux where only created
+# cannot be satisfied because wheels for numpy on AArch64/ARM64 CPUs for Linux where only created
 # since version 1.19.0, e.g. compare:
 # https://github.com/numpy/numpy/releases/tag/v1.18.4 wheels vs
 # https://github.com/numpy/numpy/releases/tag/v1.19.0
@@ -29,7 +29,7 @@ openflexure-microscope-client
 cellpose==0.6.1
 streamlit==0.81
 
-# torch==1.8.1 does not throw 'illegal instruction' SIGILL on ARM64, but newer versions might
+# torch==1.8.1 does NOT throw 'illegal instruction' SIGILL on AArch64/ARM64 CPUs, but newer versions might,
 # see https://github.com/JaidedAI/EasyOCR/issues/494#issuecomment-903576063
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==1.8.1


### PR DESCRIPTION
this adds support for AArch64/ARM64 CPUs 🚀

2 new files are created to allow both, normal x86-64 builds and AArch64/ARM64 builds

tested on Raspberry Pi 4 Model B 8GB